### PR TITLE
Fix configuration files and use better defaults

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -4,5 +4,5 @@ max-line-length=88
 max-doc-length=72
 ignore = ANN101,ANN102
 import-order-style = google
-application-import-names = stlt
+application-import-names = midori
 docstring-convention = numpy

--- a/noxfile.py
+++ b/noxfile.py
@@ -79,7 +79,7 @@ def test(session: Session) -> None:
 @session(name="coverage", python="3.9")
 def coverage(session: Session) -> None:
     """Combine and report coverage data."""
-    args = session.posargs or ["report", "-i"]
+    args = session.posargs or ["report"]
 
     session.install("coverage[toml]")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ source = ["midori"]
 omit = ["*tests*"]
 
 [tool.coverage.report]
+ignore_errors = true
 show_missing = true
 
 [tool.mypy]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,9 @@ omit = ["*tests*"]
 [tool.coverage.report]
 show_missing = true
 
+[tool.mypy]
+ignore_missing_imports = true
+
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
This fixes `application-import-names` in `.flake8`, and adds `ignore_errors` for `coverage.py` and `ignore_missing_imports` for `mypy`.